### PR TITLE
功能（）：使用`date`类型来传递日期；生成带时区信息的 ics 文件

### DIFF
--- a/cli_cqu/__init__.py
+++ b/cli_cqu/__init__.py
@@ -5,7 +5,7 @@ import logging
 import re
 import time
 from argparse import ArgumentParser
-from datetime import datetime
+from datetime import date
 from getpass import getpass
 
 from bs4 import BeautifulSoup
@@ -153,8 +153,8 @@ class App:
         schedule = ShaPingBaSchedule() if input('选择校区[0|1]> ').strip() == '0' else HuxiSchedule()
         courses = self.__get_courses()
 
-        dt: datetime = datetime.fromisoformat(input("学期开始日期 yyyy-mm-dd> ").strip())
-        cal = make_ical(courses, dt, schedule)
+        d_start: date = date.fromisoformat(input("学期开始日期 yyyy-mm-dd> ").strip())
+        cal = make_ical(courses, d_start, schedule)
         filename = input("文件名（可忽略 ics 后缀）> ").strip()
         if not filename.endswith(".ics"):
             filename = f"{filename}.ics"

--- a/cli_cqu/util/calendar.py
+++ b/cli_cqu/util/calendar.py
@@ -1,5 +1,5 @@
 """制作日历日程"""
-from datetime import datetime
+from datetime import date
 from typing import List
 from typing import Tuple
 from typing import Union
@@ -17,7 +17,7 @@ __all__ = ("make_ical")
 
 
 def make_ical(courses: List[Union[Course, ExperimentCourse]],
-              start: datetime,
+              start: date,
               schedule: Union[HuxiSchedule, ShaPingBaSchedule] = ShaPingBaSchedule()) -> Calendar:
     cal = Calendar()
     cal.add("prodid", "-//Zombie110year//CLI CQU//")
@@ -28,7 +28,7 @@ def make_ical(courses: List[Union[Course, ExperimentCourse]],
     return cal
 
 
-def build_event(course: Union[Course, ExperimentCourse], start: datetime,
+def build_event(course: Union[Course, ExperimentCourse], start: date,
                 schedule: Union[HuxiSchedule, ShaPingBaSchedule]) -> List[Event]:
     proto = Event()
     proto.add("summary", course.identifier)

--- a/cli_cqu/util/datetime.py
+++ b/cli_cqu/util/datetime.py
@@ -5,6 +5,7 @@ from datetime import date
 from datetime import datetime
 from datetime import time
 from datetime import timedelta
+from datetime import timezone
 from typing import Tuple
 from ..data.schedule import HuxiSchedule, ShaPingBaSchedule
 import re
@@ -16,20 +17,20 @@ __all__ = ("materialize_calendar")
 FULL_DAY = 14
 
 
-def materialize_calendar(t_week: str, t_lesson: str, start: datetime,
+def materialize_calendar(t_week: str, t_lesson: str, start: date,
                          schedule=ShaPingBaSchedule()) -> Tuple[datetime, datetime]:
     """具体化时间日期，将一个 周次+节次 字符串转换成具体的 datetime
 
     例如
 
-    >>> materialize_calendar(t_week="1", t_lesson="一[1-2节]", start=datetime(2020, 2, 17))
+    >>> materialize_calendar(t_week="1", t_lesson="一[1-2节]", start=date(2020, 2, 17))
     (datetime(2019, 2, 17, 8), datetime(2017, 2, 17, 9, 40))
 
     比较特殊的几种编码
 
     1. `13节`、`14节` 表示全天
 
-    >>> materialize_calendar(t_week="1", t_lesson="一[14节]", start=datetime(2020, 2, 17))
+    >>> materialize_calendar(t_week="1", t_lesson="一[14节]", start=date(2020, 2, 17))
     (datetime(2019, 2, 17, 8), datetime(2017, 2, 17, 23, 59))
     """
     p_day_lesson: re.Pattern = re.compile(r"^(?P<day>[一二三四五六日])\[(?P<lesson>[\d\-]+)节\]$")
@@ -53,10 +54,11 @@ def materialize_calendar(t_week: str, t_lesson: str, start: datetime,
         partial_times: Tuple[timedelta, timedelta] = schedule[i_lesson]
     else:
         raise TypeError(f"{i_lesson} 为 {type(i_lesson)} 类型")
-
     partial_td: Tuple[timedelta, timedelta] = (timedelta(days=partial_days) + partial_times[0],
                                                timedelta(days=partial_days) + partial_times[1])
-    result = (start + partial_td[0], start + partial_td[1])
+    # timezone(timedelta(hours=8), "Asia/Shanghai"): 北京时间
+    dt: datetime = datetime.combine(start, time.min, timezone(timedelta(hours=8), "Asia/Shanghai"))
+    result = (dt + partial_td[0], dt + partial_td[1])
     return result
 
 

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -1,9 +1,13 @@
 import pytest
-from datetime import datetime as dt
+from datetime import datetime
+from datetime import date
+from datetime import timezone, timedelta
 from cli_cqu.util.datetime import materialize_calendar
 from typing import Tuple
 START = "2020-02-17"
 
+def dt(*args):
+    return datetime(*args, tzinfo=timezone(timedelta(hours=8), "Asia/Shanghai"))
 
 @pytest.mark.parametrize("tw, tl, ex", [
     ("1", "一[1-2节]", (dt(2020, 2, 17, 8), dt(2020, 2, 17, 9, 40))),
@@ -29,4 +33,4 @@ START = "2020-02-17"
     ("2", "二[14节]", (dt(2020, 2, 25, 8), dt(2020, 2, 25, 23, 59))),
 ])
 def test_materialize_calendar(tw: str, tl: str, ex: Tuple[dt, dt]):
-    assert ex == materialize_calendar(tw, tl, start=dt(2020, 2, 17))
+    assert ex == materialize_calendar(tw, tl, start=date(2020, 2, 17))


### PR DESCRIPTION
- 建议使用`date`型来传递日期：`date`型不带时区信息，处理时不需要考虑其时区
- ics 文件带上了`Aisa/Shanghai`的时区信息