### PR TITLE
修复（calendar）：添加 VTIMEZONE 以合乎 RFC 5545 的要求

### DIFF
--- a/cli_cqu/util/calendar.py
+++ b/cli_cqu/util/calendar.py
@@ -12,7 +12,7 @@ from icalendar import Event
 
 from ..data.schedule import Schedule
 from ..model import Course, ExperimentCourse
-from ..util.datetime import materialize_calendar
+from ..util.datetime import materialize_calendar, VTIMEZONE
 
 __all__ = ("make_ical", )
 
@@ -22,6 +22,7 @@ def make_ical(courses: List[Union[Course, ExperimentCourse]], start: date,
     cal = Calendar()
     cal.add("prodid", "-//Zombie110year//CLI CQU//")
     cal.add("version", "2.0")
+    cal.add_component(VTIMEZONE)
     for course in courses:
         for ev in build_event(course, start, schedule):
             cal.add_component(ev)

--- a/cli_cqu/util/datetime.py
+++ b/cli_cqu/util/datetime.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from datetime import time
 from datetime import timedelta
 from datetime import timezone
+from icalendar import Timezone
 from typing import *
 
 from ..data.schedule import Schedule
@@ -15,6 +16,19 @@ __all__ = ("materialize_calendar", )
 
 # 14节 表示全天
 FULL_DAY = 14
+
+# 北京时间
+VTIMEZONE: Timezone = Timezone.from_ical("""BEGIN:VTIMEZONE
+TZID:Asia/Shanghai
+X-LIC-LOCATION:Asia/Shanghai
+BEGIN:STANDARD
+TZNAME:CST
+TZOFFSETFROM:+0800
+TZOFFSETTO:+0800
+DTSTART:19700101T000000
+END:STANDARD
+END:VTIMEZONE""")
+TIMEZONE: timezone = VTIMEZONE.to_tz()
 
 
 def materialize_calendar(t_week: str, t_lesson: str, start: date,
@@ -61,9 +75,7 @@ def materialize_calendar(t_week: str, t_lesson: str, start: date,
                                                partial_times[0],
                                                timedelta(days=partial_days) +
                                                partial_times[1])
-    # timezone(timedelta(hours=8), "Asia/Shanghai"): 北京时间
-    dt: datetime = datetime.combine(
-        start, time.min, timezone(timedelta(hours=8), "Asia/Shanghai"))
+    dt: datetime = datetime.combine(start, time.min, TIMEZONE)
     result = (dt + partial_td[0], dt + partial_td[1])
     return result
 


### PR DESCRIPTION
An individual "VTIMEZONE" calendar component MUST be specified for each unique "TZID" parameter value specified in the iCalendar object. (https://icalendar.org/iCalendar-RFC-5545/3-2-19-time-zone-identifier.html)

修复 #4 中加入时区信息时引入的问题